### PR TITLE
improve jobcatcher's resilience to parsing error

### DIFF
--- a/jobcatcher.py
+++ b/jobcatcher.py
@@ -132,7 +132,10 @@ class JobCatcher():
 
     def run(self):
         for item in self.jobBoardList:
-            item.fetch()
+            try:
+                item.fetch()
+            except:
+                print "Ignored (parsing error)."
 
 if __name__ == '__main__':
     parser = OptionParser(usage = 'syntax: %prog [options] <from> [to]')


### PR DESCRIPTION
This patch add an exception catching on the parsing of a downloaded item; if
the said item is ill-formed, it's reading is aborted. Previously, JobCatcher
crashed.
