### PR TITLE
L'Express board n'existe plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ soon.
 
 - Lolix.org (France)
 - Linux.com (Int.)
-- L'eXpress-Board (France)
 - Remixjobs.com (France)
 
 Help me to add new job boards to JobCatcher ! :)


### PR DESCRIPTION
Voir http://www.touilleur-express.fr/2013/11/21/arret-de-lexpress-board/
